### PR TITLE
Creating AmmoBox dividers for Costco Ammo Boxes

### DIFF
--- a/CostcoAmmoBox/AmmoBoxModel.scad
+++ b/CostcoAmmoBox/AmmoBoxModel.scad
@@ -1,0 +1,48 @@
+include <BOSL/transforms.scad>
+
+module ammoBoxModel(baseSize=[235, 100], topSize=[245, 110], height = 146, wallThickness = 2){
+
+    widthDiff = topSize[0] - baseSize[0];
+    depthDiff = topSize[1] - baseSize[1];
+
+    ceilingSize = concat(topSize, 0.001);
+    floorSize = concat(baseSize, 0.001);
+
+    difference(){
+        down(wallThickness){
+            translate([-wallThickness, -wallThickness, 0]){
+                hull() {
+                    translate([-widthDiff/2,-depthDiff/2,height + wallThickness]){
+                        cube(size=ceilingSize + [wallThickness*2, wallThickness*2, 0]);
+                    }
+                    cube(size=floorSize  + [wallThickness*2, wallThickness*2, 0]);
+                }
+            }
+        }
+        
+        hull() {
+            translate([-widthDiff/2,-depthDiff/2,height]){
+                cube(size=ceilingSize);
+            }
+            cube(size=floorSize);
+        }
+        
+    }
+}
+
+module ammoBoxInterior(baseSize=[235, 100], topSize=[245, 110], height = 146, wallThickness = 2){
+
+    widthDiff = topSize[0] - baseSize[0];
+    depthDiff = topSize[1] - baseSize[1];
+
+    ceilingSize = concat(topSize, 0.001);
+    floorSize = concat(baseSize, 0.001);
+
+    hull() {
+        translate([-widthDiff/2,-depthDiff/2,height]){
+            cube(size=ceilingSize);
+        }
+        cube(size=floorSize);
+    }
+
+}

--- a/CostcoAmmoBox/Dividers.scad
+++ b/CostcoAmmoBox/Dividers.scad
@@ -1,0 +1,53 @@
+include <BOSL/constants.scad>
+include <BOSL/transforms.scad>
+use <BOSL/masks.scad>
+use <AmmoBoxModel.scad>
+use <../Models/lattice.scad>
+
+floorWidth = 235;
+floorDepth = 100;
+
+ceilingWidth = 245;
+ceilingDepth = 110;
+
+height = 146;
+
+widthDiff = ceilingWidth - floorWidth;
+depthDiff = ceilingDepth - floorDepth;
+
+dividerThickness = 3;
+
+compartmentCountWidth = 4;
+compartmentCountDepth = 2;
+
+limitHeight = true;
+heightLimit = 90;
+
+floorSize = [floorWidth, floorDepth, 0.001];
+ceilingSize = [ceilingWidth, ceilingDepth, 0.001];
+
+if($preview){
+    ammoBoxModel(baseSize=[floorWidth, floorDepth], topSize=[ceilingWidth, ceilingDepth], height = height);
+}
+
+if(limitHeight){
+    difference(){
+        drawDividers();
+        translate([-widthDiff/2, -depthDiff/2, heightLimit]){
+            cube(ceilingSize + [0,0,height-heightLimit]);
+        }
+    }
+    
+}
+else{
+    drawDividers();
+}
+
+module drawDividers() {
+    intersection(){
+        #ammoBoxInterior(baseSize=[floorWidth, floorDepth], topSize=[ceilingWidth, ceilingDepth], height = height);
+        translate([-widthDiff/2, -depthDiff/2, 0]){
+            lattice(width=ceilingWidth, depth=ceilingDepth, height=height, widthCompartments=2, depthCompartments=2);
+        }
+    }
+}

--- a/Models/lattice.scad
+++ b/Models/lattice.scad
@@ -1,0 +1,23 @@
+include <BOSL/transforms.scad>
+
+module lattice(width=100, depth=100, height=20, latticeThickness=3, widthCompartments=3, depthCompartments=3){
+
+    trueWidth = width - (widthCompartments-1 * latticeThickness);
+    trueDepth = depth - (depthCompartments-1 * latticeThickness);
+
+    latticeWidthSize = [latticeThickness, depth, height];
+    latticeDepthSize = [width, latticeThickness, height];
+
+    for (i = [1:widthCompartments-1]){
+        right(trueWidth/widthCompartments * i){
+            cube(latticeWidthSize);
+        }
+    }
+    for (i = [1:depthCompartments-1]){
+        back(trueDepth/depthCompartments * i){
+            cube(latticeDepthSize);
+        }
+    }
+}
+
+lattice();

--- a/Powershell/DownloadLibraries.ps1
+++ b/Powershell/DownloadLibraries.ps1
@@ -1,4 +1,4 @@
-$modulePath = Join-Path$PSScriptRoot '\GithubLibraries.psd1'
+$modulePath = Join-Path $PSScriptRoot '\GithubLibraries.psd1'
 Import-Module -Name $modulePath
 
 Save-GitHubRepository -Owner rcolyer -Project threads-scad


### PR DESCRIPTION
Added here is a model files that creates dividers specifically for Costco Ammo boxes. There is an ammobox model file that is used to generate the frame that the dividers will fit inside. 

Also included is a modular lattice model that can take any size with the capability to define any number of openings in the lattice.